### PR TITLE
Add ability to share state between encryption operations

### DIFF
--- a/XSerializer.PerformanceTests/ColdStartPerformanceTests.cs
+++ b/XSerializer.PerformanceTests/ColdStartPerformanceTests.cs
@@ -82,7 +82,7 @@ namespace XSerializer.Tests.Performance
             {
                 using (var xmlReader = new XmlTextReader(stringReader))
                 {
-                    using (var reader = new XSerializerXmlReader(xmlReader, options.GetEncryptionMechanism(), options.EncryptKey))
+                    using (var reader = new XSerializerXmlReader(xmlReader, options.GetEncryptionMechanism(), options.EncryptKey, options.SerializationState))
                     {
                         customSerializer.DeserializeObject(reader, options);
                     }

--- a/XSerializer.PerformanceTests/DeserializationPerformanceTests.cs
+++ b/XSerializer.PerformanceTests/DeserializationPerformanceTests.cs
@@ -66,7 +66,7 @@ namespace XSerializer.Tests.Performance
                 {
                     using (var xmlReader = new XmlTextReader(stringReader))
                     {
-                        using (var reader = new XSerializerXmlReader(xmlReader, options.GetEncryptionMechanism(), options.EncryptKey))
+                        using (var reader = new XSerializerXmlReader(xmlReader, options.GetEncryptionMechanism(), options.EncryptKey, options.SerializationState))
                         {
                             customSerializer.DeserializeObject(reader, options);
                         }

--- a/XSerializer.Tests/Encryption/Base64EncryptionMechanism.cs
+++ b/XSerializer.Tests/Encryption/Base64EncryptionMechanism.cs
@@ -6,12 +6,12 @@ namespace XSerializer.Tests.Encryption
 {
     public class Base64EncryptionMechanism : IEncryptionMechanism
     {
-        public string Encrypt(string plainText, object encryptKey)
+        public string Encrypt(string plainText, object encryptKey, SerializationState serializationState)
         {
             return Convert.ToBase64String(Encoding.UTF8.GetBytes(plainText));
         }
 
-        public string Decrypt(string cipherText, object encryptKey)
+        public string Decrypt(string cipherText, object encryptKey, SerializationState serializationState)
         {
             return Encoding.UTF8.GetString(Convert.FromBase64String(cipherText));
         }

--- a/XSerializer.Tests/Encryption/EncryptionTests.cs
+++ b/XSerializer.Tests/Encryption/EncryptionTests.cs
@@ -24,7 +24,7 @@ namespace XSerializer.Tests.Encryption
         {
             var encryptionMechanism = new Base64EncryptionMechanism();
 
-            var serializer = new XmlSerializer<UnencryptedThing>(x => x.EncryptRootObject().WithEncryptionMechanism(encryptionMechanism).WithSerializationState(_serializationState));
+            var serializer = new XmlSerializer<UnencryptedThing>(x => x.EncryptRootObject().WithEncryptionMechanism(encryptionMechanism));
 
             var instance = new UnencryptedThing
             {
@@ -50,7 +50,7 @@ namespace XSerializer.Tests.Encryption
         {
             var encryptionMechanism = new Base64EncryptionMechanism();
 
-            var serializer = new XmlSerializer<EncryptedThing>(x => x.WithEncryptionMechanism(encryptionMechanism).WithSerializationState(_serializationState));
+            var serializer = new XmlSerializer<EncryptedThing>(x => x.WithEncryptionMechanism(encryptionMechanism));
 
             var instance = new EncryptedThing
             {
@@ -76,7 +76,7 @@ namespace XSerializer.Tests.Encryption
         {
             var encryptionMechanism = new Base64EncryptionMechanism();
 
-            var serializer = new XmlSerializer<Container<EncryptedThing>>(x => x.WithEncryptionMechanism(encryptionMechanism).WithSerializationState(_serializationState));
+            var serializer = new XmlSerializer<Container<EncryptedThing>>(x => x.WithEncryptionMechanism(encryptionMechanism));
 
             var instance = new Container<EncryptedThing>
             {
@@ -105,7 +105,7 @@ namespace XSerializer.Tests.Encryption
         {
             var encryptionMechanism = new Base64EncryptionMechanism();
 
-            var serializer = new XmlSerializer<Container<List<EncryptedThing>>>(x => x.WithEncryptionMechanism(encryptionMechanism).WithSerializationState(_serializationState));
+            var serializer = new XmlSerializer<Container<List<EncryptedThing>>>(x => x.WithEncryptionMechanism(encryptionMechanism));
 
             var instance = new Container<List<EncryptedThing>>
             {
@@ -149,7 +149,7 @@ namespace XSerializer.Tests.Encryption
         {
             var encryptionMechanism = new Base64EncryptionMechanism();
 
-            var serializer = new XmlSerializer<Container<Dictionary<EncryptedThing, int>>>(x => x.WithEncryptionMechanism(encryptionMechanism).WithSerializationState(_serializationState));
+            var serializer = new XmlSerializer<Container<Dictionary<EncryptedThing, int>>>(x => x.WithEncryptionMechanism(encryptionMechanism));
 
             var instance = new Container<Dictionary<EncryptedThing, int>>
             {
@@ -201,7 +201,7 @@ namespace XSerializer.Tests.Encryption
         {
             var encryptionMechanism = new Base64EncryptionMechanism();
 
-            var serializer = new XmlSerializer<Container<Dictionary<int, EncryptedThing>>>(x => x.WithEncryptionMechanism(encryptionMechanism).WithSerializationState(_serializationState));
+            var serializer = new XmlSerializer<Container<Dictionary<int, EncryptedThing>>>(x => x.WithEncryptionMechanism(encryptionMechanism));
 
             var instance = new Container<Dictionary<int, EncryptedThing>>
             {

--- a/XSerializer.Tests/Encryption/EncryptionTests.cs
+++ b/XSerializer.Tests/Encryption/EncryptionTests.cs
@@ -11,12 +11,20 @@ namespace XSerializer.Tests.Encryption
     [TestFixture]
     public class EncryptionTests
     {
+        private SerializationState _serializationState;
+
+        [SetUp]
+        public void Setup()
+        {
+            _serializationState = new SerializationState();
+        }
+
         [Test]
         public void CanEncryptAndDecryptEntireRootObjectViaOptions()
         {
             var encryptionMechanism = new Base64EncryptionMechanism();
 
-            var serializer = new XmlSerializer<UnencryptedThing>(x => x.EncryptRootObject().WithEncryptionMechanism(encryptionMechanism));
+            var serializer = new XmlSerializer<UnencryptedThing>(x => x.EncryptRootObject().WithEncryptionMechanism(encryptionMechanism).WithSerializationState(_serializationState));
 
             var instance = new UnencryptedThing
             {
@@ -28,8 +36,8 @@ namespace XSerializer.Tests.Encryption
 
             var doc = XDocument.Parse(xml);
 
-            Assert.That(encryptionMechanism.Decrypt(doc.Root.Value, null), Is.EqualTo("<Bar>true</Bar>"));
-            Assert.That(encryptionMechanism.Decrypt(doc.Root.Attribute("Foo").Value, null), Is.EqualTo("123"));
+            Assert.That(encryptionMechanism.Decrypt(doc.Root.Value, null, _serializationState), Is.EqualTo("<Bar>true</Bar>"));
+            Assert.That(encryptionMechanism.Decrypt(doc.Root.Attribute("Foo").Value, null, _serializationState), Is.EqualTo("123"));
 
             var roundTrip = serializer.Deserialize(xml);
 
@@ -42,7 +50,7 @@ namespace XSerializer.Tests.Encryption
         {
             var encryptionMechanism = new Base64EncryptionMechanism();
 
-            var serializer = new XmlSerializer<EncryptedThing>(x => x.WithEncryptionMechanism(encryptionMechanism));
+            var serializer = new XmlSerializer<EncryptedThing>(x => x.WithEncryptionMechanism(encryptionMechanism).WithSerializationState(_serializationState));
 
             var instance = new EncryptedThing
             {
@@ -54,8 +62,8 @@ namespace XSerializer.Tests.Encryption
 
             var doc = XDocument.Parse(xml);
 
-            Assert.That(encryptionMechanism.Decrypt(doc.Root.Value, null), Is.EqualTo("<Bar>true</Bar>"));
-            Assert.That(encryptionMechanism.Decrypt(doc.Root.Attribute("Foo").Value, null), Is.EqualTo("123"));
+            Assert.That(encryptionMechanism.Decrypt(doc.Root.Value, null, _serializationState), Is.EqualTo("<Bar>true</Bar>"));
+            Assert.That(encryptionMechanism.Decrypt(doc.Root.Attribute("Foo").Value, null, _serializationState), Is.EqualTo("123"));
 
             var roundTrip = serializer.Deserialize(xml);
 
@@ -68,7 +76,7 @@ namespace XSerializer.Tests.Encryption
         {
             var encryptionMechanism = new Base64EncryptionMechanism();
 
-            var serializer = new XmlSerializer<Container<EncryptedThing>>(x => x.WithEncryptionMechanism(encryptionMechanism));
+            var serializer = new XmlSerializer<Container<EncryptedThing>>(x => x.WithEncryptionMechanism(encryptionMechanism).WithSerializationState(_serializationState));
 
             var instance = new Container<EncryptedThing>
             {
@@ -83,8 +91,8 @@ namespace XSerializer.Tests.Encryption
 
             var doc = XDocument.Parse(xml);
 
-            Assert.That(encryptionMechanism.Decrypt(doc.Root.Element("Item").Value, null), Is.EqualTo("<Bar>true</Bar>"));
-            Assert.That(encryptionMechanism.Decrypt(doc.Root.Element("Item").Attribute("Foo").Value, null), Is.EqualTo("123"));
+            Assert.That(encryptionMechanism.Decrypt(doc.Root.Element("Item").Value, null, _serializationState), Is.EqualTo("<Bar>true</Bar>"));
+            Assert.That(encryptionMechanism.Decrypt(doc.Root.Element("Item").Attribute("Foo").Value, null, _serializationState), Is.EqualTo("123"));
 
             var roundTrip = serializer.Deserialize(xml);
 
@@ -97,7 +105,7 @@ namespace XSerializer.Tests.Encryption
         {
             var encryptionMechanism = new Base64EncryptionMechanism();
 
-            var serializer = new XmlSerializer<Container<List<EncryptedThing>>>(x => x.WithEncryptionMechanism(encryptionMechanism));
+            var serializer = new XmlSerializer<Container<List<EncryptedThing>>>(x => x.WithEncryptionMechanism(encryptionMechanism).WithSerializationState(_serializationState));
 
             var instance = new Container<List<EncryptedThing>>
             {
@@ -120,7 +128,7 @@ namespace XSerializer.Tests.Encryption
 
             var doc = XDocument.Parse(xml);
 
-            var actualDecryptedItemElementValue = encryptionMechanism.Decrypt(doc.Root.Element("Item").Value, null);
+            var actualDecryptedItemElementValue = encryptionMechanism.Decrypt(doc.Root.Element("Item").Value, null, _serializationState);
             const string expectedDecryptedItemElementValue =
                 @"<EncryptedThing Foo=""123""><Bar>true</Bar></EncryptedThing>"
                 + @"<EncryptedThing Foo=""789""><Bar>false</Bar></EncryptedThing>";
@@ -141,7 +149,7 @@ namespace XSerializer.Tests.Encryption
         {
             var encryptionMechanism = new Base64EncryptionMechanism();
 
-            var serializer = new XmlSerializer<Container<Dictionary<EncryptedThing, int>>>(x => x.WithEncryptionMechanism(encryptionMechanism));
+            var serializer = new XmlSerializer<Container<Dictionary<EncryptedThing, int>>>(x => x.WithEncryptionMechanism(encryptionMechanism).WithSerializationState(_serializationState));
 
             var instance = new Container<Dictionary<EncryptedThing, int>>
             {
@@ -170,7 +178,7 @@ namespace XSerializer.Tests.Encryption
 
             var doc = XDocument.Parse(xml);
 
-            var actualDecryptedItemElementValue = encryptionMechanism.Decrypt(doc.Root.Element("Item").Value, null);
+            var actualDecryptedItemElementValue = encryptionMechanism.Decrypt(doc.Root.Element("Item").Value, null, _serializationState);
             const string expectedDecryptedItemElementValue =
                 @"<Item><Key Foo=""123""><Bar>true</Bar></Key><Value>1</Value></Item>"
                 + @"<Item><Key Foo=""789""><Bar>false</Bar></Key><Value>2</Value></Item>";
@@ -193,7 +201,7 @@ namespace XSerializer.Tests.Encryption
         {
             var encryptionMechanism = new Base64EncryptionMechanism();
 
-            var serializer = new XmlSerializer<Container<Dictionary<int, EncryptedThing>>>(x => x.WithEncryptionMechanism(encryptionMechanism));
+            var serializer = new XmlSerializer<Container<Dictionary<int, EncryptedThing>>>(x => x.WithEncryptionMechanism(encryptionMechanism).WithSerializationState(_serializationState));
 
             var instance = new Container<Dictionary<int, EncryptedThing>>
             {
@@ -222,7 +230,7 @@ namespace XSerializer.Tests.Encryption
 
             var doc = XDocument.Parse(xml);
 
-            var actualDecryptedItemElementValue = encryptionMechanism.Decrypt(doc.Root.Element("Item").Value, null);
+            var actualDecryptedItemElementValue = encryptionMechanism.Decrypt(doc.Root.Element("Item").Value, null, _serializationState);
             const string expectedDecryptedItemElementValue =
                 @"<Item><Key>1</Key><Value Foo=""123""><Bar>true</Bar></Value></Item>"
                 + @"<Item><Key>2</Key><Value Foo=""789""><Bar>false</Bar></Value></Item>";

--- a/XSerializer.Tests/Encryption/SerializationStateExtensions.cs
+++ b/XSerializer.Tests/Encryption/SerializationStateExtensions.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace XSerializer.Tests.Encryption
+{
+    internal static class SerializationStateExtensions
+    {
+        private static readonly Func<SerializationState, object> _getRawValue;
+
+        static SerializationStateExtensions()
+        {
+            var parameter = Expression.Parameter(typeof(SerializationState), "serializationState");
+
+            var fieldInfo = typeof(SerializationState).GetField("_value", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var lambda = Expression.Lambda<Func<SerializationState, object>>(
+                Expression.Field(parameter, fieldInfo),
+                new[] { parameter });
+
+            _getRawValue = lambda.Compile();
+        }
+
+        public static object GetRawValue(this SerializationState serializationState)
+        {
+            return _getRawValue(serializationState);
+        }
+    }
+}

--- a/XSerializer.Tests/Encryption/SerializationStateTests.cs
+++ b/XSerializer.Tests/Encryption/SerializationStateTests.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using System.Text;
+using NUnit.Framework;
+using XSerializer.Encryption;
+
+namespace XSerializer.Tests.Encryption
+{
+    public class SerializationStateTests
+    {
+        public class TheGetMethod
+        {
+            [Test]
+            public void HasAnInitialValueOfNull()
+            {
+                var state = new SerializationState();
+
+                Assert.That(state.GetRawValue(), Is.Null);
+            }
+
+            [Test]
+            public void ThrowsAnExceptionIfGetValueIsNull()
+            {
+                var state = new SerializationState();
+
+                Assert.That(() => state.Get<Foo>(null), Throws.InstanceOf<ArgumentNullException>());
+            }
+
+            [Test]
+            public void ThrowsAnExceptionIfGetValueReturnsNull()
+            {
+                var state = new SerializationState();
+
+                Assert.That(() => state.Get<Foo>(() => null), Throws.ArgumentException);
+            }
+
+            [Test]
+            public void ReturnsTheObjectFromTheGetMethod()
+            {
+                var state = new SerializationState();
+
+                var foo = state.Get(() => new Foo(1));
+
+                Assert.That(foo.Bar, Is.EqualTo(1));
+            }
+
+            [Test]
+            public void ReturnsTheSameObjectFromEachCallToTheGetMethod()
+            {
+                var state = new SerializationState();
+
+                var foo1 = state.Get(() => new Foo(2));
+                var foo2 = state.Get(() => new Foo(2));
+                var foo3 = state.Get(() => new Foo(2));
+
+                Assert.That(foo1, Is.SameAs(foo2));
+                Assert.That(foo2, Is.SameAs(foo3));
+            }
+
+            private class Foo
+            {
+                private readonly int _bar;
+
+                public Foo(int bar)
+                {
+                    _bar = bar;
+                }
+
+                public int Bar
+                {
+                    get { return _bar; }
+                }
+            }
+        }
+
+        public class WhenUsedInASerializationOperation
+        {
+            private IEncryptionMechanism _current;
+            private MyEncryptionMechanism _myEncryptionMechanism;
+
+            [SetUp]
+            public void Setup()
+            {
+                _current = EncryptionMechanism.Current;
+                _myEncryptionMechanism = new MyEncryptionMechanism();
+                EncryptionMechanism.Current = _myEncryptionMechanism;
+            }
+
+            [TearDown]
+            public void TearDown()
+            {
+                EncryptionMechanism.Current = _current;
+            }
+
+            [Test]
+            public void TheSameInstanceIsUsedForEachEncryptionOperation()
+            {
+                var foo = new Foo
+                {
+                    Bar = new Bar
+                    {
+                        Grault = "abc",
+                        Qux = "xyz"
+                    },
+                    Baz = new Baz
+                    {
+                        Fred = "a1",
+                        Waldo = "b2"
+                    },
+                    Garply = "Hello, world!"
+                };
+
+                var serializationState = new SerializationState();
+                var serializer = new XmlSerializer<Foo>(x => x.WithSerializationState(serializationState).Indent());
+
+                var xml = serializer.Serialize(foo);
+
+                Assert.That(serializationState.GetRawValue(), Is.Not.Null);
+                Assert.That(serializationState.GetRawValue(), Is.InstanceOf<MyEncryptionMechanism.Counts>());
+
+                var counts = (MyEncryptionMechanism.Counts)serializationState.GetRawValue();
+
+                Assert.That(counts.DecryptInvocationCount, Is.EqualTo(0));
+                Assert.That(counts.EncryptInvocationCount, Is.EqualTo(3));
+
+                serializer.Deserialize(xml);
+
+                Assert.That(counts.DecryptInvocationCount, Is.EqualTo(3));
+                Assert.That(counts.EncryptInvocationCount, Is.EqualTo(3));
+            }
+
+            private class MyEncryptionMechanism : IEncryptionMechanism
+            {
+                public string Encrypt(string plainText, object encryptKey, SerializationState serializationState)
+                {
+                    var counts = serializationState.Get(() => new Counts());
+
+                    counts.EncryptInvocationCount++;
+
+                    return Convert.ToBase64String(Encoding.UTF8.GetBytes(plainText));
+                }
+
+                public string Decrypt(string cipherText, object encryptKey, SerializationState serializationState)
+                {
+                    var counts = serializationState.Get(() => new Counts());
+
+                    counts.DecryptInvocationCount++;
+
+                    return Encoding.UTF8.GetString(Convert.FromBase64String(cipherText));
+                }
+
+                public class Counts
+                {
+                    public int EncryptInvocationCount;
+                    public int DecryptInvocationCount;
+                }
+            }
+
+            private class Foo
+            {
+                public Bar Bar { get; set; }
+
+                public Baz Baz { get; set; }
+
+                [Encrypt]
+                public string Garply { get; set; }
+            }
+
+            private class Bar
+            {
+                public string Qux { get; set; }
+
+                [Encrypt]
+                public string Grault { get; set; }
+            }
+
+            [Encrypt]
+            private class Baz
+            {
+                public string Fred { get; set; }
+                public string Waldo { get; set; }
+            }
+        }
+    }
+}

--- a/XSerializer.Tests/TestSerializeOptions.cs
+++ b/XSerializer.Tests/TestSerializeOptions.cs
@@ -28,5 +28,6 @@ namespace XSerializer.Tests
         public bool ShouldEmitNil { get; private set; }
         public IEncryptionMechanism EncryptionMechanism { get; set; }
         public object EncryptKey { get; set; }
+        public SerializationState SerializationState { get; set; }
     }
 }

--- a/XSerializer.Tests/XSerializer.Tests.csproj
+++ b/XSerializer.Tests/XSerializer.Tests.csproj
@@ -59,6 +59,8 @@
     <Compile Include="Encryption\Base64EncryptionMechanism.cs" />
     <Compile Include="Encryption\EncryptionTests.cs" />
     <Compile Include="DerivedTypeTests.cs" />
+    <Compile Include="Encryption\SerializationStateExtensions.cs" />
+    <Compile Include="Encryption\SerializationStateTests.cs" />
     <Compile Include="GuidTests.cs" />
     <Compile Include="NilTests.cs" />
     <Compile Include="OptionsExtensions.cs" />

--- a/XSerializer.Tests/XSerializerXmlReaderWriterTests.cs
+++ b/XSerializer.Tests/XSerializerXmlReaderWriterTests.cs
@@ -14,7 +14,7 @@ namespace XSerializer.Tests
         {
             var sb = new StringBuilder();
             var encryptionMechanism = new Base64EncryptionMechanism();
-            var options = new TestSerializeOptions { EncryptionMechanism = encryptionMechanism };
+            var options = new TestSerializeOptions { EncryptionMechanism = encryptionMechanism, SerializationState = new SerializationState() };
 
             using (var stringWriter = new StringWriter(sb))
             {
@@ -52,7 +52,7 @@ namespace XSerializer.Tests
                 }
             }
 
-            Func<string, string> e = x => encryptionMechanism.Encrypt(x, null);
+            Func<string, string> e = x => encryptionMechanism.Encrypt(x, null, options.SerializationState);
 
             // reference xml:
             // <foo><bar baz="123"><qux>abc</qux></bar><rab zab="789"><xuq>xyz</xuq></rab></foo>
@@ -70,7 +70,7 @@ namespace XSerializer.Tests
             {
                 using (var xmlReader = new XmlTextReader(stringReader))
                 {
-                    using (var reader = new XSerializerXmlReader(xmlReader, encryptionMechanism, null))
+                    using (var reader = new XSerializerXmlReader(xmlReader, encryptionMechanism, null, options.SerializationState))
                     {
                         reader.Read(); // None -> <foo>
                         reader.IsDecryptionEnabled = true;
@@ -113,7 +113,7 @@ namespace XSerializer.Tests
         {
             var sb = new StringBuilder();
             var encryptionMechanism = new Base64EncryptionMechanism();
-            var options = new TestSerializeOptions { EncryptionMechanism = encryptionMechanism };
+            var options = new TestSerializeOptions { EncryptionMechanism = encryptionMechanism, SerializationState = new SerializationState() };
 
             using (var stringWriter = new StringWriter(sb))
             {
@@ -153,7 +153,7 @@ namespace XSerializer.Tests
                 }
             }
 
-            Func<string, string> e = x => encryptionMechanism.Encrypt(x, null);
+            Func<string, string> e = x => encryptionMechanism.Encrypt(x, null, options.SerializationState);
 
             // reference xml:
             // <foo><bar baz="123"><qux>abc</qux></bar><rab zab="789"><xuq>xyz</xuq></rab></foo>
@@ -176,7 +176,7 @@ namespace XSerializer.Tests
             {
                 using (var xmlReader = new XmlTextReader(stringReader))
                 {
-                    using (var reader = new XSerializerXmlReader(xmlReader, encryptionMechanism, null))
+                    using (var reader = new XSerializerXmlReader(xmlReader, encryptionMechanism, null, options.SerializationState))
                     {
                         reader.Read(); // None -> <foo>
 
@@ -220,7 +220,7 @@ namespace XSerializer.Tests
         {
             var sb = new StringBuilder();
             var encryptionMechanism = new Base64EncryptionMechanism();
-            var options = new TestSerializeOptions { EncryptionMechanism = encryptionMechanism };
+            var options = new TestSerializeOptions { EncryptionMechanism = encryptionMechanism, SerializationState = new SerializationState() };
 
             using (var stringWriter = new StringWriter(sb))
             {
@@ -260,7 +260,7 @@ namespace XSerializer.Tests
                 }
             }
 
-            Func<string, string> e = x => encryptionMechanism.Encrypt(x, null);
+            Func<string, string> e = x => encryptionMechanism.Encrypt(x, null, options.SerializationState);
 
             // reference xml:
             // <foo><bar baz="123"><qux>abc</qux></bar><rab zab="789"><xuq>xyz</xuq></rab></foo>
@@ -283,7 +283,7 @@ namespace XSerializer.Tests
             {
                 using (var xmlReader = new XmlTextReader(stringReader))
                 {
-                    using (var reader = new XSerializerXmlReader(xmlReader, encryptionMechanism, options.EncryptKey))
+                    using (var reader = new XSerializerXmlReader(xmlReader, encryptionMechanism, options.EncryptKey, options.SerializationState))
                     {
                         reader.Read(); // None -> <foo>
 
@@ -326,7 +326,7 @@ namespace XSerializer.Tests
         {
             var sb = new StringBuilder();
             var encryptionMechanism = new Base64EncryptionMechanism();
-            var options = new TestSerializeOptions { EncryptionMechanism = encryptionMechanism };
+            var options = new TestSerializeOptions { EncryptionMechanism = encryptionMechanism, SerializationState = new SerializationState() };
 
             using (var stringWriter = new StringWriter(sb))
             {
@@ -366,7 +366,7 @@ namespace XSerializer.Tests
                 }
             }
 
-            Func<string, string> e = x => encryptionMechanism.Encrypt(x, null);
+            Func<string, string> e = x => encryptionMechanism.Encrypt(x, null, options.SerializationState);
 
             // reference xml:
             // <foo><bar baz="123"><qux>abc</qux></bar><rab zab="789"><xuq>xyz</xuq></rab></foo>
@@ -389,7 +389,7 @@ namespace XSerializer.Tests
             {
                 using (var xmlReader = new XmlTextReader(stringReader))
                 {
-                    using (var reader = new XSerializerXmlReader(xmlReader, encryptionMechanism, options.EncryptKey))
+                    using (var reader = new XSerializerXmlReader(xmlReader, encryptionMechanism, options.EncryptKey, options.SerializationState))
                     {
                         reader.Read(); // None -> <foo>
 

--- a/XSerializer/Encryption/ClearTextEncryptionMechanism.cs
+++ b/XSerializer/Encryption/ClearTextEncryptionMechanism.cs
@@ -12,8 +12,9 @@
         /// </summary>
         /// <param name="text">Some text.</param>
         /// <param name="encryptKey">Ignored.</param>
+        /// <param name="serializationState">Ignored.</param>
         /// <returns>The value of <paramref name="text"/>.</returns>
-        public string Encrypt(string text, object encryptKey)
+        public string Encrypt(string text, object encryptKey, SerializationState serializationState)
         {
             return text;
         }
@@ -23,8 +24,9 @@
         /// </summary>
         /// <param name="text">Some text.</param>
         /// <param name="encryptKey">Ignored.</param>
+        /// <param name="serializationState">Ignored.</param>
         /// <returns>The value of <paramref name="text"/>.</returns>
-        public string Decrypt(string text, object encryptKey)
+        public string Decrypt(string text, object encryptKey, SerializationState serializationState)
         {
             return text;
         }

--- a/XSerializer/Encryption/EncryptionMechanism.cs
+++ b/XSerializer/Encryption/EncryptionMechanism.cs
@@ -122,7 +122,7 @@
         /// </summary>
         internal static IEncryptionMechanism GetEncryptionMechanism(this ISerializeOptions options)
         {
-            return options.EncryptionMechanism ?? _current;
+            return options.EncryptionMechanism ?? Current;
         }
 
         private static ClearTextEncryptionMechanism GetDefaultEncryptionMechanism()

--- a/XSerializer/Encryption/EncryptionMechanism.cs
+++ b/XSerializer/Encryption/EncryptionMechanism.cs
@@ -35,7 +35,7 @@
         /// <returns>The encrypted text.</returns>
         public static string Encrypt(string plainText)
         {
-            return Encrypt(plainText, null);
+            return Encrypt(plainText, null, null);
         }
 
         /// <summary>
@@ -49,7 +49,25 @@
         /// <returns>The encrypted text.</returns>
         public static string Encrypt(string plainText, object encryptKey)
         {
-            return Current.Encrypt(plainText, encryptKey);
+            return Encrypt(plainText, encryptKey, null);
+        }
+
+        /// <summary>
+        /// Encrypts the specified plain text using the <see cref="IEncryptionMechanism"/>
+        /// specified by the <see cref="Current"/> property.
+        /// </summary>
+        /// <param name="plainText">The plain text.</param>
+        /// <param name="encryptKey">
+        /// An object to used to look up invokation-specific encryption parameters.
+        /// </param>
+        /// <param name="serializationState">
+        /// An object that holds an arbitrary value that is passed to one or more
+        /// encrypt operations within a single serialization operation.
+        /// </param>
+        /// <returns>The encrypted text.</returns>
+        public static string Encrypt(string plainText, object encryptKey, SerializationState serializationState)
+        {
+            return Current.Encrypt(plainText, encryptKey, serializationState);
         }
 
         /// <summary>
@@ -60,7 +78,7 @@
         /// <returns>The decrypted text.</returns>
         public static string Decrypt(string cipherText)
         {
-            return Decrypt(cipherText, null);
+            return Decrypt(cipherText, null, null);
         }
 
         /// <summary>
@@ -74,7 +92,25 @@
         /// <returns>The decrypted text.</returns>
         public static string Decrypt(string cipherText, object encryptKey)
         {
-            return Current.Decrypt(cipherText, encryptKey);
+            return Decrypt(cipherText, encryptKey, null);
+        }
+
+        /// <summary>
+        /// Decrypts the specified cipher text using the <see cref="IEncryptionMechanism"/>
+        /// specified by the <see cref="Current"/> property.
+        /// </summary>
+        /// <param name="cipherText">The cipher text.</param>
+        /// <param name="encryptKey">
+        /// An object to used to look up invokation-specific encryption parameters.
+        /// </param>
+        /// <param name="serializationState">
+        /// An object that holds an arbitrary value that is passed to one or more
+        /// decrypt operations within a single serialization operation.
+        /// </param>
+        /// <returns>The decrypted text.</returns>
+        public static string Decrypt(string cipherText, object encryptKey, SerializationState serializationState)
+        {
+            return Current.Decrypt(cipherText, encryptKey, serializationState);
         }
 
         /// <summary>

--- a/XSerializer/Encryption/IEncryptionMechanism.cs
+++ b/XSerializer/Encryption/IEncryptionMechanism.cs
@@ -12,6 +12,10 @@
         /// <param name="encryptKey">
         /// An object to used to look up invokation-specific encryption parameters.
         /// </param>
+        /// <param name="serializationState">
+        /// An object that holds an arbitrary value that is passed to one or more
+        /// encrypt operations within a single serialization operation.
+        /// </param>
         /// <returns>The encrypted text.</returns>
         /// <remarks>
         /// <para>
@@ -28,7 +32,7 @@
         /// the <paramref name="encryptKey"/> parameter altogether.
         /// </para>
         /// </remarks>
-        string Encrypt(string plainText, object encryptKey);
+        string Encrypt(string plainText, object encryptKey, SerializationState serializationState);
 
         /// <summary>
         /// Decrypts the specified cipher text.
@@ -36,6 +40,10 @@
         /// <param name="cipherText">The cipher text.</param>
         /// <param name="encryptKey">
         /// An object to used to look up invokation-specific encryption parameters.
+        /// </param>
+        /// <param name="serializationState">
+        /// An object that holds an arbitrary value that is passed to one or more
+        /// decrypt operations within a single serialization operation.
         /// </param>
         /// <returns>The decrypted text.</returns>
         /// <remarks>
@@ -53,6 +61,6 @@
         /// the <paramref name="encryptKey"/> parameter altogether.
         /// </para>
         /// </remarks>
-        string Decrypt(string cipherText, object encryptKey);
+        string Decrypt(string cipherText, object encryptKey, SerializationState serializationState);
     }
 }

--- a/XSerializer/ISerializeOptions.cs
+++ b/XSerializer/ISerializeOptions.cs
@@ -12,5 +12,6 @@ namespace XSerializer
         bool ShouldEmitNil { get; }
         IEncryptionMechanism EncryptionMechanism { get; }
         object EncryptKey { get; }
+        SerializationState SerializationState { get; }
     }
 }

--- a/XSerializer/Properties/AssemblyInfo.cs
+++ b/XSerializer/Properties/AssemblyInfo.cs
@@ -37,7 +37,7 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.1.0.0")]
 [assembly: AssemblyFileVersion("0.2.1")]
-[assembly: AssemblyInformationalVersion("0.2.1-alpha02")]
+[assembly: AssemblyInformationalVersion("0.2.1")]
 
 [assembly: InternalsVisibleTo("XSerializer.Tests")]
 [assembly: InternalsVisibleTo("XSerializer.PerformanceTests")]

--- a/XSerializer/Properties/AssemblyInfo.cs
+++ b/XSerializer/Properties/AssemblyInfo.cs
@@ -37,7 +37,7 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.1.0.0")]
 [assembly: AssemblyFileVersion("0.2.1")]
-[assembly: AssemblyInformationalVersion("0.2.1-alpha01")]
+[assembly: AssemblyInformationalVersion("0.2.1-alpha02")]
 
 [assembly: InternalsVisibleTo("XSerializer.Tests")]
 [assembly: InternalsVisibleTo("XSerializer.PerformanceTests")]

--- a/XSerializer/Properties/AssemblyInfo.cs
+++ b/XSerializer/Properties/AssemblyInfo.cs
@@ -36,8 +36,8 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.1.0.0")]
-[assembly: AssemblyFileVersion("0.2.0")]
-[assembly: AssemblyInformationalVersion("0.2.0")]
+[assembly: AssemblyFileVersion("0.2.1")]
+[assembly: AssemblyInformationalVersion("0.2.1-alpha01")]
 
 [assembly: InternalsVisibleTo("XSerializer.Tests")]
 [assembly: InternalsVisibleTo("XSerializer.PerformanceTests")]

--- a/XSerializer/SerializationExtensions.cs
+++ b/XSerializer/SerializationExtensions.cs
@@ -127,7 +127,7 @@ namespace XSerializer
             {
                 using (var xmlReader = new XmlTextReader(stringReader))
                 {
-                    using (var reader = new XSerializerXmlReader(xmlReader, options.GetEncryptionMechanism(), options.EncryptKey))
+                    using (var reader = new XSerializerXmlReader(xmlReader, options.GetEncryptionMechanism(), options.EncryptKey, options.SerializationState))
                     {
                         return serializer.DeserializeObject(reader, options);
                     }
@@ -138,14 +138,14 @@ namespace XSerializer
         public static object DeserializeObject(this IXmlSerializerInternal serializer, Stream stream, ISerializeOptions options)
         {
             var xmlReader = new XmlTextReader(stream);
-            var reader = new XSerializerXmlReader(xmlReader, options.GetEncryptionMechanism(), options.EncryptKey);
+            var reader = new XSerializerXmlReader(xmlReader, options.GetEncryptionMechanism(), options.EncryptKey, options.SerializationState);
             return serializer.DeserializeObject(reader, options);
         }
 
         public static object DeserializeObject(this IXmlSerializerInternal serializer, TextReader textReader, ISerializeOptions options)
         {
             var xmlReader = new XmlTextReader(textReader);
-            var reader = new XSerializerXmlReader(xmlReader, options.GetEncryptionMechanism(), options.EncryptKey);
+            var reader = new XSerializerXmlReader(xmlReader, options.GetEncryptionMechanism(), options.EncryptKey, options.SerializationState);
             return serializer.DeserializeObject(reader, options);
         }
 

--- a/XSerializer/SerializationExtensions.cs
+++ b/XSerializer/SerializationExtensions.cs
@@ -62,6 +62,8 @@ namespace XSerializer
             Formatting formatting,
             ISerializeOptions options)
         {
+            options = options.WithNewSerializationState();
+
             var sb = new StringBuilder();
 
             using (var stringWriter = new StringWriterWithEncoding(sb, encoding ?? Encoding.UTF8))
@@ -84,6 +86,8 @@ namespace XSerializer
             Formatting formatting,
             ISerializeOptions options)
         {
+            options = options.WithNewSerializationState();
+
             StreamWriter streamWriter = null;
 
             try
@@ -113,6 +117,8 @@ namespace XSerializer
             Formatting formatting,
             ISerializeOptions options)
         {
+            options = options.WithNewSerializationState();
+
             var xmlWriter = new XSerializerXmlTextWriter(writer, options)
             {
                 Formatting = formatting
@@ -123,6 +129,8 @@ namespace XSerializer
 
         public static object DeserializeObject(this IXmlSerializerInternal serializer, string xml, ISerializeOptions options)
         {
+            options = options.WithNewSerializationState();
+
             using (var stringReader = new StringReader(xml))
             {
                 using (var xmlReader = new XmlTextReader(stringReader))
@@ -137,6 +145,8 @@ namespace XSerializer
 
         public static object DeserializeObject(this IXmlSerializerInternal serializer, Stream stream, ISerializeOptions options)
         {
+            options = options.WithNewSerializationState();
+
             var xmlReader = new XmlTextReader(stream);
             var reader = new XSerializerXmlReader(xmlReader, options.GetEncryptionMechanism(), options.EncryptKey, options.SerializationState);
             return serializer.DeserializeObject(reader, options);
@@ -144,9 +154,38 @@ namespace XSerializer
 
         public static object DeserializeObject(this IXmlSerializerInternal serializer, TextReader textReader, ISerializeOptions options)
         {
+            options = options.WithNewSerializationState();
+
             var xmlReader = new XmlTextReader(textReader);
             var reader = new XSerializerXmlReader(xmlReader, options.GetEncryptionMechanism(), options.EncryptKey, options.SerializationState);
             return serializer.DeserializeObject(reader, options);
+        }
+
+        private static ISerializeOptions WithNewSerializationState(this ISerializeOptions serializeOptions)
+        {
+            return new SerializeOptions
+            {
+                EncryptionMechanism = serializeOptions.EncryptionMechanism,
+                EncryptKey = serializeOptions.EncryptKey,
+                Namespaces = serializeOptions.Namespaces,
+                SerializationState = new SerializationState(),
+                ShouldAlwaysEmitTypes = serializeOptions.ShouldAlwaysEmitTypes,
+                ShouldEmitNil = serializeOptions.ShouldEmitNil,
+                ShouldEncrypt = serializeOptions.ShouldEncrypt,
+                ShouldRedact = serializeOptions.ShouldRedact
+            };
+        }
+
+        private class SerializeOptions : ISerializeOptions
+        {
+            public XmlSerializerNamespaces Namespaces { get; set; }
+            public bool ShouldAlwaysEmitTypes { get; set; }
+            public bool ShouldRedact { get; set; }
+            public bool ShouldEncrypt { get; set; }
+            public bool ShouldEmitNil { get; set; }
+            public IEncryptionMechanism EncryptionMechanism { get; set; }
+            public object EncryptKey { get; set; }
+            public SerializationState SerializationState { get; set; }
         }
 
         /// <summary>

--- a/XSerializer/SerializationState.cs
+++ b/XSerializer/SerializationState.cs
@@ -1,0 +1,51 @@
+﻿using System;
+
+namespace XSerializer
+{
+    /// <summary>
+    /// An object that holds an arbitrary value, to be used by one or more encrypt/decrypt
+    /// operations within a single serialization operation.
+    /// </summary>
+    public sealed class SerializationState
+    {
+        private readonly object _locker = new object();
+
+        private volatile object _value;
+
+        /// <summary>
+        /// Gets the value.
+        /// </summary>
+        /// <typeparam name="T">The type of the value.</typeparam>
+        /// <param name="getValue">A function that produces the value. This function will only be executed if this method has never been called before.</param>
+        /// <returns>The value</returns>
+        public T Get<T>(Func<T> getValue)
+        {
+            if (getValue == null) throw new ArgumentNullException("getValue");
+
+            if (_value == null)
+            {
+                lock (_locker)
+                {
+                    if (_value == null)
+                    {
+                        var instance = getValue();
+
+                        if (instance == null)
+                        {
+                            throw new ArgumentException("The 'getValue' function must return a non-null value.", "getValue");
+                        }
+
+                        _value = instance;
+                    }
+                }
+            }
+
+            if (!(_value is T))
+            {
+                throw new InvalidOperationException("The previously created value is not assignable to type " + typeof(T));
+            }
+
+            return (T)_value;
+        }
+    }
+}

--- a/XSerializer/XSerializer.csproj
+++ b/XSerializer/XSerializer.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Rock.StaticDependencyInjection\ExportAttribute.cs" />
     <Compile Include="Rock.StaticDependencyInjection\ModuleInitializer.cs" />
     <Compile Include="Rock.StaticDependencyInjection\StaticDependencyInjection.Generated.cs" />
+    <Compile Include="SerializationState.cs" />
     <Compile Include="ValueTypes.cs" />
     <Compile Include="TypeTypeValueConverter.cs" />
     <Compile Include="UriTypeValueConverter.cs" />

--- a/XSerializer/XSerializerXmlTextWriter.cs
+++ b/XSerializer/XSerializerXmlTextWriter.cs
@@ -23,7 +23,7 @@ namespace XSerializer
         private bool _hasWritternDefaultDocumentNamespaces;
 
         public XSerializerXmlTextWriter(TextWriter writer, ISerializeOptions options)
-            : this(new EncryptingTextWriter(writer, options.GetEncryptionMechanism(), options.EncryptKey), options)
+            : this(new EncryptingTextWriter(writer, options.GetEncryptionMechanism(), options.EncryptKey, options.SerializationState), options)
         {
         }
 
@@ -230,12 +230,14 @@ namespace XSerializer
             private readonly TextWriter _writer;
             private readonly IEncryptionMechanism _encryptionMechanism;
             private readonly object _encryptKey;
+            private readonly SerializationState _serializationState;
 
-            public EncryptingTextWriter(TextWriter writer, IEncryptionMechanism encryptionMechanism, object encryptKey)
+            public EncryptingTextWriter(TextWriter writer, IEncryptionMechanism encryptionMechanism, object encryptKey, SerializationState serializationState)
             {
                 _writer = writer;
                 _encryptionMechanism = encryptionMechanism;
                 _encryptKey = encryptKey;
+                _serializationState = serializationState;
             }
 
             public bool IsEncryptionEnabled { get; set; }
@@ -272,7 +274,7 @@ namespace XSerializer
 
                 if (IsEncryptionEnabled)
                 {
-                    value = _encryptionMechanism.Encrypt(value, _encryptKey);
+                    value = _encryptionMechanism.Encrypt(value, _encryptKey, _serializationState);
                 }
 
                 _writer.Write(value);

--- a/XSerializer/XmlSerializationOptions.cs
+++ b/XSerializer/XmlSerializationOptions.cs
@@ -21,6 +21,7 @@ namespace XSerializer
         private bool _emitNil;
         private IEncryptionMechanism _encryptionMechanism;
         private object _encryptKey;
+        private SerializationState _serializationState;
 
         public XmlSerializationOptions(
             XmlSerializerNamespaces namespaces = null,
@@ -35,7 +36,8 @@ namespace XSerializer
             bool treatEmptyElementAsString = false,
             bool emitNil = false,
             IEncryptionMechanism encryptionMechanism = null,
-            object encryptKey = null)
+            object encryptKey = null,
+            SerializationState serializationState = null)
         {
             _namespaces = namespaces ?? new XmlSerializerNamespaces();
             _encoding = encoding ?? Encoding.UTF8;
@@ -51,6 +53,7 @@ namespace XSerializer
             _emitNil = emitNil;
             _encryptionMechanism = encryptionMechanism;
             _encryptKey = encryptKey;
+            _serializationState = serializationState ?? new SerializationState();
         }
 
         internal Encoding Encoding { get { return _encoding; } }
@@ -75,6 +78,7 @@ namespace XSerializer
 
         IEncryptionMechanism ISerializeOptions.EncryptionMechanism { get { return _encryptionMechanism; } }
         object ISerializeOptions.EncryptKey { get { return _encryptKey; } }
+        SerializationState ISerializeOptions.SerializationState { get { return _serializationState; } }
 
         internal void SetExtraTypes(Type[] extraTypes)
         {
@@ -156,6 +160,17 @@ namespace XSerializer
         public XmlSerializationOptions WithEncryptKey(object encryptKey)
         {
             _encryptKey = encryptKey;
+            return this;
+        }
+
+        public XmlSerializationOptions WithSerializationState(SerializationState serializationState)
+        {
+            if (serializationState == null)
+            {
+                throw new ArgumentNullException("serializationState");
+            }
+
+            _serializationState = serializationState;
             return this;
         }
     }

--- a/XSerializer/XmlSerializationOptions.cs
+++ b/XSerializer/XmlSerializationOptions.cs
@@ -21,7 +21,6 @@ namespace XSerializer
         private bool _emitNil;
         private IEncryptionMechanism _encryptionMechanism;
         private object _encryptKey;
-        private SerializationState _serializationState;
 
         public XmlSerializationOptions(
             XmlSerializerNamespaces namespaces = null,
@@ -36,8 +35,7 @@ namespace XSerializer
             bool treatEmptyElementAsString = false,
             bool emitNil = false,
             IEncryptionMechanism encryptionMechanism = null,
-            object encryptKey = null,
-            SerializationState serializationState = null)
+            object encryptKey = null)
         {
             _namespaces = namespaces ?? new XmlSerializerNamespaces();
             _encoding = encoding ?? Encoding.UTF8;
@@ -53,7 +51,6 @@ namespace XSerializer
             _emitNil = emitNil;
             _encryptionMechanism = encryptionMechanism;
             _encryptKey = encryptKey;
-            _serializationState = serializationState ?? new SerializationState();
         }
 
         internal Encoding Encoding { get { return _encoding; } }
@@ -78,7 +75,7 @@ namespace XSerializer
 
         IEncryptionMechanism ISerializeOptions.EncryptionMechanism { get { return _encryptionMechanism; } }
         object ISerializeOptions.EncryptKey { get { return _encryptKey; } }
-        SerializationState ISerializeOptions.SerializationState { get { return _serializationState; } }
+        SerializationState ISerializeOptions.SerializationState { get { return null; } }
 
         internal void SetExtraTypes(Type[] extraTypes)
         {
@@ -160,17 +157,6 @@ namespace XSerializer
         public XmlSerializationOptions WithEncryptKey(object encryptKey)
         {
             _encryptKey = encryptKey;
-            return this;
-        }
-
-        public XmlSerializationOptions WithSerializationState(SerializationState serializationState)
-        {
-            if (serializationState == null)
-            {
-                throw new ArgumentNullException("serializationState");
-            }
-
-            _serializationState = serializationState;
             return this;
         }
     }


### PR DESCRIPTION
Implementations of `IEncryptionMechanism` may be expensive (e.g. round-trip to a server to obtain a private key) and need to be able to minimize impact. To do so, the should be able to share arbitrary state between different encryption operations within a single serialization operation.