### PR TITLE
Bug fix: two xml element attributed string properties weren't possible

### DIFF
--- a/XSerializer.Tests/AttributedPropertyTests.cs
+++ b/XSerializer.Tests/AttributedPropertyTests.cs
@@ -8,6 +8,25 @@ namespace XSerializer.Tests
 {
     public class AttributedPropertyTests
     {
+        [Test]
+        public void TwoXmlElementAttributedStringPropertiesArePossible()
+        {
+            var serializer = new XmlSerializer<TwoXmlElementAttributedStringProperties>();
+            var wtf = new TwoXmlElementAttributedStringProperties { Foo = "abc", Bar = "xyz" };
+            var xml = serializer.Serialize(wtf);
+            var wtf2 = serializer.Deserialize(xml);
+            Assert.That(wtf2, Has.PropertiesEqualTo(wtf));
+        }
+
+        public class TwoXmlElementAttributedStringProperties
+        {
+            [XmlElement("FOO")]
+            public string Foo { get; set; }
+
+            [XmlElement("BAR")]
+            public string Bar { get; set; }
+        }
+
         [TestCaseSource("TestCaseData")]
         public void CustomSerializerThrowsExceptionIfAndOnlyIfBclXmlSerializerDoes(Type type)
         {

--- a/XSerializer/SerializableProperty.cs
+++ b/XSerializer/SerializableProperty.cs
@@ -30,6 +30,7 @@ namespace XSerializer
                 ?? (EncryptAttribute)Attribute.GetCustomAttribute(propertyInfo.PropertyType, typeof(EncryptAttribute));
             _isListDecoratedWithXmlElement =
                 typeof(IEnumerable).IsAssignableFrom(propertyInfo.PropertyType)
+                && !(propertyInfo.PropertyType == typeof(string))
                 && Attribute.GetCustomAttributes(propertyInfo, typeof(XmlElementAttribute)).Any();
 
             _getValueFunc = DynamicMethodFactory.CreateFunc<object>(propertyInfo.GetGetMethod());


### PR DESCRIPTION
Given a class with two string properties with both decorated with an `XmlElementAttribute`, an error is thrown upon the creation of an `XmlSerializer<T>`.

> System.InvalidOperationException : More than one list property is decorated with [XmlElement] attribute.

```c#
public class Test
{
    [XmlElement("LOANNUMBER")]
    public string LoanNumber { get; set; }
    
    [XmlElement("CUSTOMER_ID_")]
    public string CommonId { get; set; }
}
```