### PR TITLE
Be more lenient when deserializing json primitives

### DIFF
--- a/XSerializer.Tests/JsonBooleanTests.cs
+++ b/XSerializer.Tests/JsonBooleanTests.cs
@@ -1,0 +1,24 @@
+using NUnit.Framework;
+
+namespace XSerializer.Tests
+{
+    public class JsonBooleanTests
+    {
+        [Test]
+        public void CanDeserializeJsonBooleanAsString()
+        {
+            var serializer = new JsonSerializer<FooString>();
+
+            var json = @"{""Bar"":true}"; // Boolean not wrapped in quotes
+
+            var result = serializer.Deserialize(json);
+
+            Assert.That(result.Bar, Is.EqualTo("true"));
+        }
+
+        public class FooString
+        {
+            public string Bar { get; set; }
+        }
+    }
+}

--- a/XSerializer.Tests/JsonNumberTests.cs
+++ b/XSerializer.Tests/JsonNumberTests.cs
@@ -1,0 +1,24 @@
+using NUnit.Framework;
+
+namespace XSerializer.Tests
+{
+    public class JsonNumberTests
+    {
+        [Test]
+        public void CanDeserializeJsonNumberAsString()
+        {
+            var serializer = new JsonSerializer<FooString>();
+
+            var json = @"{""Bar"":123.45}"; // Number not wrapped in quotes
+
+            var result = serializer.Deserialize(json);
+
+            Assert.That(result.Bar, Is.EqualTo("123.45"));
+        }
+
+        public class FooString
+        {
+            public string Bar { get; set; }
+        }
+    }
+}

--- a/XSerializer.Tests/JsonStringTests.cs
+++ b/XSerializer.Tests/JsonStringTests.cs
@@ -1,0 +1,60 @@
+using NUnit.Framework;
+
+namespace XSerializer.Tests
+{
+    public class JsonStringTests
+    {
+        [Test]
+        public void CanDeserializeJsonStringAsInt()
+        {
+            var serializer = new JsonSerializer<FooInt>();
+
+            var json = @"{""Bar"":""123""}";
+
+            var result = serializer.Deserialize(json);
+
+            Assert.That(result.Bar, Is.EqualTo(123));
+        }
+
+        [Test]
+        public void CanDeserializeJsonStringAsDouble()
+        {
+            var serializer = new JsonSerializer<FooDouble>();
+
+            var json = @"{""Bar"":""123.45""}";
+
+            var result = serializer.Deserialize(json);
+
+            Assert.That(result.Bar, Is.EqualTo(123.45));
+        }
+
+        [TestCase("true", true)]
+        [TestCase("false", false)]
+        [TestCase("", null)]
+        public void CanDeserializeJsonStringAsBool(string stringValue, object expectedValue)
+        {
+            var serializer = new JsonSerializer<FooBool>();
+
+            var json = @"{""Bar"":""" + stringValue + @"""}";
+
+            var result = serializer.Deserialize(json);
+
+            Assert.That(result.Bar, Is.EqualTo(expectedValue));
+        }
+
+        public class FooInt
+        {
+            public int Bar { get; set; }
+        }
+
+        public class FooDouble
+        {
+            public double Bar { get; set; }
+        }
+
+        public class FooBool
+        {
+            public bool? Bar { get; set; }
+        }
+    }
+}

--- a/XSerializer.Tests/JsonStringTests.cs
+++ b/XSerializer.Tests/JsonStringTests.cs
@@ -4,28 +4,30 @@ namespace XSerializer.Tests
 {
     public class JsonStringTests
     {
-        [Test]
-        public void CanDeserializeJsonStringAsInt()
+        [TestCase("123", 123)]
+        [TestCase("", null)]
+        public void CanDeserializeJsonStringAsInt(string stringValue, int? expectedValue)
         {
             var serializer = new JsonSerializer<FooInt>();
 
-            var json = @"{""Bar"":""123""}";
+            var json = @"{""Bar"":""" + stringValue + @"""}";
 
             var result = serializer.Deserialize(json);
 
-            Assert.That(result.Bar, Is.EqualTo(123));
+            Assert.That(result.Bar, Is.EqualTo(expectedValue));
         }
 
-        [Test]
-        public void CanDeserializeJsonStringAsDouble()
+        [TestCase("123.45", 123.45)]
+        [TestCase("", null)]
+        public void CanDeserializeJsonStringAsDouble(string stringValue, double? expectedValue)
         {
             var serializer = new JsonSerializer<FooDouble>();
 
-            var json = @"{""Bar"":""123.45""}";
+            var json = @"{""Bar"":""" + stringValue + @"""}";
 
             var result = serializer.Deserialize(json);
 
-            Assert.That(result.Bar, Is.EqualTo(123.45));
+            Assert.That(result.Bar, Is.EqualTo(expectedValue));
         }
 
         [TestCase("true", true)]
@@ -44,12 +46,12 @@ namespace XSerializer.Tests
 
         public class FooInt
         {
-            public int Bar { get; set; }
+            public int? Bar { get; set; }
         }
 
         public class FooDouble
         {
-            public double Bar { get; set; }
+            public double? Bar { get; set; }
         }
 
         public class FooBool

--- a/XSerializer.Tests/XSerializer.Tests.csproj
+++ b/XSerializer.Tests/XSerializer.Tests.csproj
@@ -56,6 +56,8 @@
     <Compile Include="BclXmlSerializerExtensions.cs" />
     <Compile Include="BooleanJsonSerializerTests.cs" />
     <Compile Include="JsonArrayTests.cs" />
+    <Compile Include="JsonBooleanTests.cs" />
+    <Compile Include="JsonNumberTests.cs" />
     <Compile Include="JsonObjectTests.cs" />
     <Compile Include="CustomJsonSerializerTests.cs" />
     <Compile Include="DateTimeOffsetTests.cs" />
@@ -70,6 +72,7 @@
     <Compile Include="GuidTests.cs" />
     <Compile Include="JsonReaderTests.cs" />
     <Compile Include="JsonSerializerFactoryTests.cs" />
+    <Compile Include="JsonStringTests.cs" />
     <Compile Include="JsonWriterTests.cs" />
     <Compile Include="ListJsonSerializerTests.cs" />
     <Compile Include="NilTests.cs" />

--- a/XSerializer/BooleanJsonSerializer.cs
+++ b/XSerializer/BooleanJsonSerializer.cs
@@ -81,7 +81,26 @@ namespace XSerializer
         {
             if (reader.NodeType != JsonNodeType.Boolean)
             {
-                if (!_nullable && reader.NodeType != JsonNodeType.Null)
+                if (reader.NodeType == JsonNodeType.String)
+                {
+                    var value = (string)reader.Value;
+
+                    if (value == "true")
+                    {
+                        return true;
+                    }
+
+                    if (value == "false")
+                    {
+                        return false;
+                    }
+
+                    if (_nullable && value == "")
+                    {
+                        return null;
+                    }
+                }
+                else if (!_nullable && reader.NodeType != JsonNodeType.Null)
                 {
                     throw new XSerializerException(string.Format(
                         "Unexpected node type '{0}' encountered in '{1}.DeserializeObject' method.",

--- a/XSerializer/NumberJsonSerializer.cs
+++ b/XSerializer/NumberJsonSerializer.cs
@@ -160,7 +160,7 @@ namespace XSerializer
             readFunc =
                 !type.IsNullableType()
                     ? readFuncLocal
-                    : value => value == null ? null : readFuncLocal(value);
+                    : value => string.IsNullOrEmpty(value) ? null : readFuncLocal(value);
         }
     }
 }

--- a/XSerializer/NumberJsonSerializer.cs
+++ b/XSerializer/NumberJsonSerializer.cs
@@ -75,7 +75,8 @@ namespace XSerializer
 
         private object Read(JsonReader reader)
         {
-            if (reader.NodeType != JsonNodeType.Number)
+            if (reader.NodeType != JsonNodeType.Number
+                && reader.NodeType != JsonNodeType.String)
             {
                 if (!_nullable && reader.NodeType != JsonNodeType.Null)
                 {
@@ -96,7 +97,7 @@ namespace XSerializer
         {
             Func<string, object> readFuncLocal;
 
-            if (type == typeof(double) || type == typeof(double?) || type == null)
+            if (type == typeof(double) || type == typeof(double?))
             {
                 writeAction = (writer, value) => writer.WriteValue((double)value);
                 readFuncLocal = value => double.Parse(value);

--- a/XSerializer/StringJsonSerializer.cs
+++ b/XSerializer/StringJsonSerializer.cs
@@ -75,18 +75,33 @@ namespace XSerializer
 
         private object Read(JsonReader reader, IJsonSerializeOperationInfo info)
         {
-            if (reader.NodeType != JsonNodeType.String)
+            string value;
+
+            switch (reader.NodeType)
             {
-                if (!_nullable && reader.NodeType != JsonNodeType.Null)
-                {
-                    throw new XSerializerException(string.Format(
-                        "Unexpected node type '{0}' encountered in '{1}.DeserializeObject' method.",
-                        reader.NodeType,
-                        typeof(StringJsonSerializer)));
-                }
+                case JsonNodeType.Number:
+                case JsonNodeType.String:
+                    value = (string)reader.Value;
+                    break;
+                case JsonNodeType.Boolean:
+                    value = (bool)reader.Value ? "true" : "false";
+                    break;
+                default:
+                    if (_nullable && reader.NodeType == JsonNodeType.Null)
+                    {
+                        value = null;
+                    }
+                    else
+                    {
+                        throw new XSerializerException(string.Format(
+                            "Unexpected node type '{0}' encountered in '{1}.DeserializeObject' method.",
+                            reader.NodeType,
+                            typeof(StringJsonSerializer)));
+                    }
+                    break;
             }
 
-            return _read((string)reader.Value, info);
+            return _read(value, info);
         }
 
         private void SetDelegates(


### PR DESCRIPTION
- Accept json number and json boolean when deserializing into string.
- Accept json string when deserializing into numeric type, but only if the value actually is a number.  If deserializing into a nullable numeric type, also accept empty string.
- Accept json string when deserializing into bool, but only if the value is "true" or "false". If deserializing into nullable bool, also accept empty string.