### PR TITLE
The default value of string is null, not `new string()`

### DIFF
--- a/XSerializer/SimpleTypeValueConverter.cs
+++ b/XSerializer/SimpleTypeValueConverter.cs
@@ -202,7 +202,7 @@ namespace XSerializer
             }
 
             {
-                var defaultValue = Activator.CreateInstance(type);
+                var defaultValue = type.IsValueType ? Activator.CreateInstance(type) : null;
                 return (value, options) => string.IsNullOrEmpty(value) ? defaultValue : Convert.ChangeType(value, type);
             }
         }


### PR DESCRIPTION
I should run *all* the unit tests before committing. Sigh.