### PR TITLE
Fix Xml duplicate name bug

### DIFF
--- a/XSerializer.Tests/XSerializer.Tests.csproj
+++ b/XSerializer.Tests/XSerializer.Tests.csproj
@@ -116,6 +116,7 @@
     <Compile Include="TestSerializeOptions.cs" />
     <Compile Include="TestXmlSerializerOptions.cs" />
     <Compile Include="TimeSpanTests.cs" />
+    <Compile Include="XmlBugTests.cs" />
     <Compile Include="XmlRootAttributeTests.cs" />
     <Compile Include="XmlSerializerFactoryTests.cs" />
     <Compile Include="XmlSerializerOfTypeUriTests.cs" />

--- a/XSerializer.Tests/XmlBugTests.cs
+++ b/XSerializer.Tests/XmlBugTests.cs
@@ -1,0 +1,48 @@
+﻿using NUnit.Framework;
+
+namespace XSerializer.Tests
+{
+    public class XmlBugTests
+    {
+        [Test]
+        public void AnUnknownElementWithTheSameNameAsAKnownElementDoesNotClearOutTheKnownValue()
+        {
+            var xml = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
+<Data>
+    <Person>
+        <Name>
+            <First>Bilbo</First>
+            <Last>Baggins</Last>
+        </Name>
+        <Pet>
+            <Type>Cat</Type>
+            <Name>Fluffy</Name>
+        </Pet>
+    </Person>
+</Data>";
+
+            var serializer = new XmlSerializer<Data>();
+
+            var data = serializer.Deserialize(xml);
+
+            Assert.That(data.Person.Name.First, Is.EqualTo("Bilbo"));
+            Assert.That(data.Person.Name.Last, Is.EqualTo("Baggins"));
+        }
+    }
+
+    public class Data
+    {
+        public Person Person { get; set; }
+    }
+
+    public class Person
+    {
+        public Name Name { get; set; }
+    }
+
+    public class Name
+    {
+        public string First { get; set; }
+        public string Last { get; set; }
+    }
+}


### PR DESCRIPTION
Given the following classes:

```c#
public class Data
{
    public Person Person { get; set; }
}

public class Person
{
    public Name Name { get; set; }
}

public class Name
{
    public string First { get; set; }
    public string Last { get; set; }
}
```

And an xml document like this (note that there is an "unknown" element, `Pet` with a child element `Name` that is the same as the "known" element `Name` under person):

```xml
<?xml version=""1.0"" encoding=""utf-8"" ?>
<Data>
    <Person>
        <Name>
            <First>Bilbo</First>
            <Last>Baggins</Last>
        </Name>
        <Pet>
            <Type>Cat</Type>
            <Name>Fluffy</Name>
        </Pet>
    </Person>
</Data>
```

When this situation occurs, the unknown `Name` element is deserialized and the resulting value is set to `Person.Name`.