### PR TITLE
Fix bad cache key strategy

### DIFF
--- a/XSerializer/CacheKeyEqualityComparer.cs
+++ b/XSerializer/CacheKeyEqualityComparer.cs
@@ -83,10 +83,7 @@ namespace XSerializer
 
                 key = (key * 397) ^ (string.IsNullOrWhiteSpace(options.RootElementName) ? type.Name : options.RootElementName).GetHashCode();
 
-                if (options.RedactAttribute != null)
-                {
-                    key = (key * 397) ^ options.RedactAttribute.GetHashCode();
-                }
+                key = (key * 397) ^ (options.RedactAttribute != null).GetHashCode();
 
                 key = (key * 397) ^ (encryptAttribute != null).GetHashCode();
 

--- a/XSerializer/CacheKeyEqualityComparer.cs
+++ b/XSerializer/CacheKeyEqualityComparer.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using CacheKey = System.Tuple<System.Type, XSerializer.Encryption.EncryptAttribute, XSerializer.IXmlSerializerOptions>;
+
+namespace XSerializer
+{
+    internal class CacheKeyEqualityComparer : IEqualityComparer<CacheKey>
+    {
+        public bool Equals(CacheKey lhs, CacheKey rhs)
+        {
+            var lhsType = lhs.Item1;
+            var lhsEncryptAttribute = lhs.Item2;
+            var lhsOptions = lhs.Item3;
+
+            var rhsType = rhs.Item1;
+            var rhsEncryptAttribute = rhs.Item2;
+            var rhsOptions = rhs.Item3;
+
+            if (lhsType != rhsType) return false;
+
+            if (lhsOptions.DefaultNamespace != rhsOptions.DefaultNamespace) return false;
+
+            if ((lhsOptions.ExtraTypes == null) != (rhsOptions.ExtraTypes == null)) return false;
+            if (lhsOptions.ExtraTypes != null)
+            {
+                var lhsExtraTypes = lhsOptions.ExtraTypes
+                    .Where(extraType => extraType != null)
+                    .Distinct(EqualityComparer<Type>.Default)
+                    .OrderBy(extraType => extraType.FullName)
+                    .GetEnumerator();
+                var rhsExtraTypes = rhsOptions.ExtraTypes
+                    .Where(extraType => extraType != null)
+                    .Distinct(EqualityComparer<Type>.Default)
+                    .OrderBy(extraType => extraType.FullName)
+                    .GetEnumerator();
+                while (true)
+                {
+                    bool hasNext;
+                    if ((hasNext = lhsExtraTypes.MoveNext()) != rhsExtraTypes.MoveNext()) return false;
+                    if (!hasNext) break;
+                    if (lhsExtraTypes.Current != rhsExtraTypes.Current) return false;
+                }
+            }
+
+            var lhsRootElementName = string.IsNullOrWhiteSpace(lhsOptions.RootElementName) ? lhsType.Name : lhsOptions.RootElementName;
+            var rhsRootElementName = string.IsNullOrWhiteSpace(rhsOptions.RootElementName) ? rhsType.Name : rhsOptions.RootElementName;
+            if (lhsRootElementName != rhsRootElementName) return false;
+
+            if ((lhsOptions.RedactAttribute == null) != (rhsOptions.RedactAttribute == null)) return false;
+
+            if ((lhsEncryptAttribute == null) != (rhsEncryptAttribute == null)) return false;
+
+            if (lhsOptions.TreatEmptyElementAsString != rhsOptions.TreatEmptyElementAsString) return false;
+
+            if (lhsOptions.ShouldUseAttributeDefinedInInterface != rhsOptions.ShouldUseAttributeDefinedInInterface) return false;
+
+            return true;
+        }
+
+        public int GetHashCode(CacheKey cacheKey)
+        {
+            unchecked
+            {
+                var type = cacheKey.Item1;
+                var encryptAttribute = cacheKey.Item2;
+                var options = cacheKey.Item3;
+
+                var key = type.GetHashCode();
+
+                key = (key * 397) ^ (string.IsNullOrWhiteSpace(options.DefaultNamespace) ? "" : options.DefaultNamespace).GetHashCode();
+
+                if (options.ExtraTypes != null)
+                {
+                    key = options.ExtraTypes
+                        .Where(extraType => extraType != null)
+                        .Distinct(EqualityComparer<Type>.Default)
+                        .OrderBy(extraType => extraType.FullName)
+                        .Aggregate(key, (current, extraType) => (current * 397) ^ extraType.GetHashCode());
+                }
+
+                key = (key * 397) ^ (string.IsNullOrWhiteSpace(options.RootElementName) ? type.Name : options.RootElementName).GetHashCode();
+
+                if (options.RedactAttribute != null)
+                {
+                    key = (key * 397) ^ options.RedactAttribute.GetHashCode();
+                }
+
+                key = (key * 397) ^ (encryptAttribute != null).GetHashCode();
+
+                key = (key * 397) ^ options.TreatEmptyElementAsString.GetHashCode();
+
+                key = (key * 397) ^ options.ShouldAlwaysEmitNil.GetHashCode();
+
+                key = (key * 397) ^ options.ShouldUseAttributeDefinedInInterface.GetHashCode();
+
+                return key;
+            }
+        }
+    }
+}

--- a/XSerializer/CacheKeyEqualityComparer.cs
+++ b/XSerializer/CacheKeyEqualityComparer.cs
@@ -53,6 +53,8 @@ namespace XSerializer
 
             if (lhsOptions.TreatEmptyElementAsString != rhsOptions.TreatEmptyElementAsString) return false;
 
+            if (lhsOptions.ShouldAlwaysEmitNil != rhsOptions.ShouldAlwaysEmitNil) return false;
+
             if (lhsOptions.ShouldUseAttributeDefinedInInterface != rhsOptions.ShouldUseAttributeDefinedInInterface) return false;
 
             return true;

--- a/XSerializer/CustomSerializer.cs
+++ b/XSerializer/CustomSerializer.cs
@@ -10,17 +10,18 @@ using System.Runtime.Serialization;
 using System.Xml;
 using System.Xml.Serialization;
 using XSerializer.Encryption;
+using CacheKey = System.Tuple<System.Type, XSerializer.Encryption.EncryptAttribute, XSerializer.IXmlSerializerOptions>;
 
 namespace XSerializer
 {
     internal class CustomSerializer
     {
-        private static readonly ConcurrentDictionary<int, IXmlSerializerInternal> _serializerCache = new ConcurrentDictionary<int, IXmlSerializerInternal>();
+        private static readonly ConcurrentDictionary<CacheKey, IXmlSerializerInternal> _serializerCache = new ConcurrentDictionary<CacheKey, IXmlSerializerInternal>(new CacheKeyEqualityComparer());
 
         public static IXmlSerializerInternal GetSerializer(Type type, EncryptAttribute encryptAttribute, IXmlSerializerOptions options)
         {
             return _serializerCache.GetOrAdd(
-                XmlSerializerFactory.Instance.CreateKey(type, encryptAttribute, options),
+                Tuple.Create(type, encryptAttribute, options),
                 _ =>
                 {
                     try

--- a/XSerializer/DictionarySerializer.cs
+++ b/XSerializer/DictionarySerializer.cs
@@ -6,12 +6,13 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Xml;
 using XSerializer.Encryption;
+using CacheKey = System.Tuple<System.Type, XSerializer.Encryption.EncryptAttribute, XSerializer.IXmlSerializerOptions>;
 
 namespace XSerializer
 {
     internal abstract class DictionarySerializer : IXmlSerializerInternal
     {
-        private static readonly ConcurrentDictionary<int, IXmlSerializerInternal> _serializerCache = new ConcurrentDictionary<int, IXmlSerializerInternal>();
+        private static readonly ConcurrentDictionary<CacheKey, IXmlSerializerInternal> _serializerCache = new ConcurrentDictionary<CacheKey, IXmlSerializerInternal>(new CacheKeyEqualityComparer());
 
         protected readonly EncryptAttribute _encryptAttribute;
         private readonly IXmlSerializerOptions _options;
@@ -256,7 +257,7 @@ namespace XSerializer
         public static IXmlSerializerInternal GetSerializer(Type type, EncryptAttribute encryptAttribute, IXmlSerializerOptions options)
         {
             return _serializerCache.GetOrAdd(
-                XmlSerializerFactory.Instance.CreateKey(type, encryptAttribute, options),
+                Tuple.Create(type, encryptAttribute, options),
                 _ =>
                 {
                     Func<Type, IXmlSerializerInternal> createDictionarySerializer =

--- a/XSerializer/ListSerializer.cs
+++ b/XSerializer/ListSerializer.cs
@@ -6,12 +6,13 @@ using System.Linq;
 using System.Reflection;
 using System.Xml;
 using XSerializer.Encryption;
+using CacheKey = System.Tuple<System.Type, XSerializer.Encryption.EncryptAttribute, XSerializer.IXmlSerializerOptions>;
 
 namespace XSerializer
 {
     internal abstract class ListSerializer : IXmlSerializerInternal
     {
-        private static readonly ConcurrentDictionary<int, IXmlSerializerInternal> _serializerCache = new ConcurrentDictionary<int, IXmlSerializerInternal>();
+        private static readonly ConcurrentDictionary<CacheKey, IXmlSerializerInternal> _serializerCache = new ConcurrentDictionary<CacheKey, IXmlSerializerInternal>(new CacheKeyEqualityComparer());
 
         private readonly EncryptAttribute _encryptAttribute;
         private readonly IXmlSerializerOptions _options;
@@ -73,7 +74,7 @@ namespace XSerializer
         public static IXmlSerializerInternal GetSerializer(Type type, EncryptAttribute encryptAttribute, IXmlSerializerOptions options, string itemElementName)
         {
             return _serializerCache.GetOrAdd(
-                XmlSerializerFactory.Instance.CreateKey(type, encryptAttribute, options.WithRootElementName(options.RootElementName + "<>" + itemElementName)),
+                Tuple.Create(type, encryptAttribute, options.WithRootElementName(options.RootElementName + "<>" + itemElementName)),
                 _ =>
                 {
                     if (type.IsAssignableToGenericIEnumerable())

--- a/XSerializer/SerializationExtensions.cs
+++ b/XSerializer/SerializationExtensions.cs
@@ -30,7 +30,7 @@ namespace XSerializer
 
         private static readonly Dictionary<Type, string> _typeToXsdTypeMap = new Dictionary<Type, string>();
         private static readonly Dictionary<string, Type> _xsdTypeToTypeMap = new Dictionary<string, Type>();
-        private static readonly ConcurrentDictionary<int, Type> _xsdTypeToTypeCache = new ConcurrentDictionary<int, Type>();
+        private static readonly ConcurrentDictionary<Tuple<Type, string>, Type> _xsdTypeToTypeCache = new ConcurrentDictionary<Tuple<Type, string>, Type>();
 
         static SerializationExtensions()
         {
@@ -1088,7 +1088,7 @@ namespace XSerializer
             }
 
             return _xsdTypeToTypeCache.GetOrAdd(
-                CreateTypeCacheKey<T>(typeName),
+                Tuple.Create(typeof(T), typeName),
                 _ =>
                 {
                     Type type = null;
@@ -1199,16 +1199,6 @@ namespace XSerializer
 
                     return type;
                 });
-        }
-
-        private static int CreateTypeCacheKey<T>(string typeName)
-        {
-            unchecked
-            {
-                var key = typeof(T).GetHashCode();
-                key = (key * 397) ^ typeName.GetHashCode();
-                return key;
-            }
         }
     }
 }

--- a/XSerializer/SimpleTypeValueConverter.cs
+++ b/XSerializer/SimpleTypeValueConverter.cs
@@ -6,7 +6,7 @@ namespace XSerializer
 {
     internal class SimpleTypeValueConverter : IValueConverter
     {
-        private static readonly ConcurrentDictionary<int, SimpleTypeValueConverter> _map = new ConcurrentDictionary<int, SimpleTypeValueConverter>();
+        private static readonly ConcurrentDictionary<Tuple<Type, bool>, SimpleTypeValueConverter> _map = new ConcurrentDictionary<Tuple<Type, bool>, SimpleTypeValueConverter>();
 
         private readonly Func<string, ISerializeOptions, object> _parseString;
         private readonly Func<object, ISerializeOptions, string> _getString;
@@ -28,7 +28,7 @@ namespace XSerializer
         public static SimpleTypeValueConverter Create(Type type, RedactAttribute redactAttribute)
         {
             return _map.GetOrAdd(
-                CreateKey(type, redactAttribute),
+                Tuple.Create(type, redactAttribute != null),
                 _ => new SimpleTypeValueConverter(type, redactAttribute));
         }
 
@@ -502,21 +502,6 @@ namespace XSerializer
         private static string GetStringFromNullableChar(object value, ISerializeOptions options)
         {
             return value == null ? null : GetStringFromChar(value, options);
-        }
-
-        private static int CreateKey(Type type, RedactAttribute redactAttribute)
-        {
-            unchecked
-            {
-                var key = type.GetHashCode();
-
-                if (redactAttribute != null)
-                {
-                    key = (key * 397) ^ redactAttribute.GetHashCode();
-                }
-
-                return key;
-            }
         }
     }
 }

--- a/XSerializer/XSerializer.csproj
+++ b/XSerializer/XSerializer.csproj
@@ -62,6 +62,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BooleanJsonSerializer.cs" />
+    <Compile Include="CacheKeyEqualityComparer.cs" />
     <Compile Include="JsonMappingAttribute.cs" />
     <Compile Include="CustomJsonSerializer.cs" />
     <Compile Include="DateTimeHandler.cs" />


### PR DESCRIPTION
In the old strategy, cache keys were of type `int`, meaning that if there was a hash collision, it was impossible to resolve using `Equals` as a tie-breaker. The new strategy uses keys of type `Tuple`, in conjunction with a custom `IEqualityComparer`.