### PR TITLE
Fix null literal bug for encrypted properties

### DIFF
--- a/XSerializer.Tests/Encryption/PlaintextEncryptedPropertyTests.cs
+++ b/XSerializer.Tests/Encryption/PlaintextEncryptedPropertyTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using XSerializer.Encryption;
 
@@ -47,6 +48,41 @@ namespace XSerializer.Tests.Encryption
             Assert.That(foo.Garply, Is.EqualTo(123.45M));
             Assert.That(foo.Grault.Count, Is.EqualTo(1));
             Assert.That(foo.Grault[0], Is.EqualTo(456));
+        }
+
+        [Test]
+        [TestCase(@"{""Foo"":null,""Baz"":null,""Qux"":null,""Corge"":null,""Garply"":null,""Grault"":null,""Fred"":null,""Waldo"":null}")]
+        [TestCase(@"{""Foo"":""Encrypted::null::Encrypted"",""Baz"":""Encrypted::null::Encrypted"",""Qux"":""Encrypted::null::Encrypted"",""Corge"":""Encrypted::null::Encrypted"",""Garply"":""Encrypted::null::Encrypted"",""Grault"":""Encrypted::null::Encrypted"",""Fred"":""Encrypted::null::Encrypted"",""Waldo"":""Encrypted::null::Encrypted""}")]
+        public void CanJsonDeserializeNullLiteralsIntoEncryptedProperties(string json)
+        {
+            var serializer = new JsonSerializer<Bar>(
+                new JsonSerializerConfiguration
+                {
+                    EncryptionMechanism = new FakeEncryptionMechanism()
+                });
+
+            var bar = serializer.Deserialize(json);
+
+            Assert.That(bar.Foo, Is.Null);
+            Assert.That(bar.Baz, Is.Null);
+            Assert.That(bar.Qux, Is.Null);
+            Assert.That(bar.Corge, Is.Null);
+            Assert.That(bar.Garply, Is.Null);
+            Assert.That(bar.Grault, Is.Null);
+            Assert.That(bar.Fred, Is.Null);
+            Assert.That(bar.Waldo, Is.Null);
+        }
+
+        public class Bar
+        {
+            [Encrypt] public Dictionary<string, object> Foo { get; set; }
+            [Encrypt] public int[] Baz { get; set; }
+            [Encrypt] public Qux Qux { get; set; }
+            [Encrypt] public bool? Corge { get; set; }
+            [Encrypt] public int? Garply { get; set; }
+            [Encrypt] public object Grault { get; set; }
+            [Encrypt] public string Fred { get; set; }
+            [Encrypt] public DateTime? Waldo { get; set; }
         }
 
         public class Foo

--- a/XSerializer/BooleanJsonSerializer.cs
+++ b/XSerializer/BooleanJsonSerializer.cs
@@ -95,7 +95,7 @@ namespace XSerializer
                     {
                         if (!exception)
                         {
-                            if (reader.DecryptReads && (reader.ReadContent(path) || reader.NodeType == JsonNodeType.Invalid))
+                            if (reader.NodeType != JsonNodeType.Null && reader.DecryptReads && (reader.ReadContent(path) || reader.NodeType == JsonNodeType.Invalid))
                             {
                                 throw new MalformedDocumentException(MalformedDocumentError.ExpectedEndOfDecryptedString,
                                     path, reader.Value, reader.Line, reader.Position, null, reader.NodeType);

--- a/XSerializer/CustomJsonSerializer.cs
+++ b/XSerializer/CustomJsonSerializer.cs
@@ -179,6 +179,11 @@ namespace XSerializer
 
         private object Read(JsonReader reader, IJsonSerializeOperationInfo info, string path)
         {
+            if (reader.NodeType == JsonNodeType.Null)
+            {
+                return null;
+            }
+
             var factory = _createObjectFactory.Value.Invoke();
 
             foreach (var propertyName in reader.ReadProperties(path))

--- a/XSerializer/DictionaryJsonSerializer.cs
+++ b/XSerializer/DictionaryJsonSerializer.cs
@@ -165,6 +165,11 @@ namespace XSerializer
 
         private object Read(JsonReader reader, IJsonSerializeOperationInfo info, string path)
         {
+            if (reader.NodeType == JsonNodeType.Null)
+            {
+                return null;
+            }
+
             var dictionary = _createDictionary();
 
             foreach (var keyString in reader.ReadProperties(path))

--- a/XSerializer/DynamicJsonSerializer.cs
+++ b/XSerializer/DynamicJsonSerializer.cs
@@ -157,7 +157,7 @@ namespace XSerializer
                     {
                         if (!exception)
                         {
-                            if (reader.DecryptReads && (reader.ReadContent(path) || reader.NodeType == JsonNodeType.Invalid))
+                            if (reader.NodeType != JsonNodeType.Null && reader.DecryptReads && (reader.ReadContent(path) || reader.NodeType == JsonNodeType.Invalid))
                             {
                                 throw new MalformedDocumentException(MalformedDocumentError.ExpectedEndOfDecryptedString,
                                     path, reader.Value, reader.Line, reader.Position, null, reader.NodeType);

--- a/XSerializer/JsonReader.cs
+++ b/XSerializer/JsonReader.cs
@@ -88,12 +88,7 @@ namespace XSerializer
             }
             else
             {
-                if (NodeType == JsonNodeType.Null)
-                {
-                    return;
-                }
-
-                if (_decryptedReader.Peek() != -1)
+                if (NodeType != JsonNodeType.Null && _decryptedReader.Peek() != -1)
                 {
                     throw new InvalidOperationException("Attempted to set DecryptReads to false before the encrypted stream has been consumed.");
                 }

--- a/XSerializer/ListJsonSerializer.cs
+++ b/XSerializer/ListJsonSerializer.cs
@@ -168,7 +168,7 @@ namespace XSerializer
                     {
                         if (!exception)
                         {
-                            if (reader.DecryptReads && (reader.ReadContent(path) || reader.NodeType == JsonNodeType.Invalid))
+                            if (reader.NodeType != JsonNodeType.Null && reader.DecryptReads && (reader.ReadContent(path) || reader.NodeType == JsonNodeType.Invalid))
                             {
                                 throw new MalformedDocumentException(MalformedDocumentError.ExpectedEndOfDecryptedString,
                                     path, reader.Value, reader.Line, reader.Position, null, reader.NodeType);

--- a/XSerializer/NumberJsonSerializer.cs
+++ b/XSerializer/NumberJsonSerializer.cs
@@ -94,7 +94,7 @@ namespace XSerializer
                     {
                         if (!exception)
                         {
-                            if (reader.DecryptReads && (reader.ReadContent(path) || reader.NodeType == JsonNodeType.Invalid))
+                            if (reader.NodeType != JsonNodeType.Null && reader.DecryptReads && (reader.ReadContent(path) || reader.NodeType == JsonNodeType.Invalid))
                             {
                                 throw new MalformedDocumentException(MalformedDocumentError.ExpectedEndOfDecryptedString,
                                     path, reader.Value, reader.Line, reader.Position, null, reader.NodeType);

--- a/XSerializer/StringJsonSerializer.cs
+++ b/XSerializer/StringJsonSerializer.cs
@@ -80,6 +80,7 @@ namespace XSerializer
                     case JsonNodeType.Number:
                     case JsonNodeType.String:
                     case JsonNodeType.Boolean:
+                    case JsonNodeType.Null:
                         break;
                     case JsonNodeType.EndOfString:
                         throw new MalformedDocumentException(MalformedDocumentError.MissingValue,


### PR DESCRIPTION
An exception would be thrown if a class had a nullable property marked with the [Encrypt] attribute and was deserialized from a json string that had a null literal value for the encrypted property.